### PR TITLE
[#4] PseudoTcpSharp integration

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "PseudoTcpSharp"]
+	path = PseudoTcpSharp
+	url = https://github.com/psantosl/PseudoTcpSharp.git

--- a/Config.cs
+++ b/Config.cs
@@ -1,0 +1,15 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace p2pcopy
+{
+    public class Config
+    {
+        // Attempt connection every 15s, max 5s for NAT traversal, max 5s for TCP handshake
+        public static List<int> CONNECTION_SYNC_TIMES = new List<int>() {15, 30, 45, 60};
+        public static int NAT_TRAVERSAL_TRIES = 1;
+        public static int MAX_TRAVERSAL_TIME = 5000;
+        public static int PUNCH_PKTS_PER_TRY = 5;
+        public static int MAX_TCP_HANDSHAKE_TIME = 5000;
+    }
+}

--- a/FodyWeavers.xml
+++ b/FodyWeavers.xml
@@ -1,8 +1,3 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Weavers>
-    <Costura>
-        <Unmanaged64Assemblies>
-            UdtProtocol
-        </Unmanaged64Assemblies>
-    </Costura>
 </Weavers>

--- a/InternetTime.cs
+++ b/InternetTime.cs
@@ -14,9 +14,11 @@ namespace p2pcopy
 
             DateTime dateTime = DateTime.MinValue;
 
-            System.Net.ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls12 | SecurityProtocolType.Tls11 | SecurityProtocolType.Tls;
+            System.Net.ServicePointManager.SecurityProtocol = 
+                (SecurityProtocolType)(0xc0 | 0x300 | 0xc00);
+                // SecurityProtocolType.Tls12 | SecurityProtocolType.Tls11 | SecurityProtocolType.Tls;
 
-            HttpWebRequest request = (HttpWebRequest)WebRequest.Create("https://nist.time.gov/actualtime.cgi?lzbc=siqm9b");
+            HttpWebRequest request = (HttpWebRequest)WebRequest.Create ("http://worldtimeapi.org/api/timezone/Europe/London.txt");
             request.Method = "GET";
             request.Accept = "text/html, application/xhtml+xml, */*";
             request.UserAgent = "p2pcopy";
@@ -26,9 +28,9 @@ namespace p2pcopy
             if (response.StatusCode == HttpStatusCode.OK)
             {
                 StreamReader stream = new StreamReader(response.GetResponseStream());
-                string html = stream.ReadToEnd();//<timestamp time=\"1395772696469995\" delay=\"1395772696469995\"/>
-                string time = Regex.Match(html, @"(?<=\btime="")[^""]*").Value;
-                double milliseconds = Convert.ToInt64(time) / 1000.0;
+                string html = stream.ReadToEnd();//<timestamp time=\"1395772696469995\" delay=\"1395772696469995\"/>                
+                string time = Regex.Match(html, @"(?<=unixtime: )[^u]*").Value;
+                double milliseconds = Convert.ToInt64(time) * 1000.0;
                 dateTime = new DateTime(1970, 1, 1).AddMilliseconds(milliseconds).ToLocalTime();
             }
 

--- a/PLog.cs
+++ b/PLog.cs
@@ -1,0 +1,13 @@
+﻿using System;
+
+namespace p2pcopy
+{
+	public class PLog
+	{
+		public static void DEBUG(string fmt, params object[] args)
+		{
+			//Console.WriteLine(string.Format(fmt, args));
+		}
+	}
+}
+	

--- a/Program.cs
+++ b/Program.cs
@@ -28,6 +28,7 @@ namespace p2pcopy
             Socket socket = new Socket(
                 AddressFamily.InterNetwork,
                 SocketType.Dgram, ProtocolType.Udp);
+                socket.SetSocketOption (SocketOptionLevel.Socket, SocketOptionName.ReuseAddress, true);
 
             try
             {
@@ -46,6 +47,9 @@ namespace p2pcopy
                 PseudoTcpSocket connection;
                 if (false==testWithLocalhost) {
                     P2pEndPoint p2pEndPoint = GetExternalEndPoint(socket);
+
+                    Console.WriteLine("p2pEndPoint external=" + p2pEndPoint.External);
+                    Console.WriteLine("p2pEndPoint internal=" + p2pEndPoint.Internal);
 
                     if (p2pEndPoint == null)
                         return;
@@ -230,7 +234,7 @@ namespace p2pcopy
                     Console.WriteLine("Getting internet time");
                     DateTime now = InternetTime.Get();
 
-                    int sleepTimeToSync = SleepTime(now) + (cla.Sender ? 1:0);
+                    int sleepTimeToSync = SleepTime(now);
 
                     Console.WriteLine("[{0}] - Waiting {1} sec to sync with other peer",
                         now.ToLongTimeString(),
@@ -238,7 +242,9 @@ namespace p2pcopy
                     System.Threading.Thread.Sleep(sleepTimeToSync * 1000);
 
                     if (false==testWithLocalhost) {
+                        Console.WriteLine ("Before 2nd call to GetExternalEndPoint, socket.LocalEndPoint=" + socket.LocalEndPoint);
                         GetExternalEndPoint(socket);
+                        Console.WriteLine ("After 2nd call to GetExternalEndPoint, socket.localEndPoint=" + socket.LocalEndPoint);
                     }
                         
                     PseudoTcpSocket.Callbacks cbs = new PseudoTcpSocket.Callbacks();
@@ -249,7 +255,7 @@ namespace p2pcopy
                     cbs.PseudoTcpClosed = icbs.Closed;
                     client = PseudoTcpSocket.Create(0, cbs);
                     client.NotifyMtu(1496); // Per PseudoTcpTests
-                    icbs.Init(localAddr, localPort, remoteAddr, remotePort, client);
+                    icbs.Init(localAddr, localPort, remoteAddr, remotePort, client, socket);
                     PLog.DEBUG("Created PseudoTcpSocket");
 
                     Console.WriteLine("\r{0} - Trying to connect to {1}:{2}.  ",

--- a/Receiver.cs
+++ b/Receiver.cs
@@ -4,60 +4,83 @@ using System.IO;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using PseudoTcp;
+using System.Threading;
 
 namespace p2pcopy
 {
     static class Receiver
     {
-        static internal void Run(Udt.Socket conn)
+        static internal void Run(PseudoTcpSocket conn)
         {
+            PLog.DEBUG ("In Receiver.Run");
             int ini = Environment.TickCount;
 
-            using (Udt.NetworkStream netStream = new Udt.NetworkStream(conn))
-            using (BinaryWriter writer = new BinaryWriter(netStream))
-            using (BinaryReader reader = new BinaryReader(netStream))
+            byte[] ackBuffer = new byte[1];
+            ackBuffer [0] = 1;
+            long got = 0;
+
+            byte[] fnlBytes = new byte[4];
+            got = SyncPseudoTcpSocket.Recv(conn,fnlBytes,4);
+            PLog.DEBUG ("Reading filename length, got={0}", got);
+            SyncPseudoTcpSocket.Send(conn,ackBuffer,1);
+            uint fileNameLengthBytes = (uint)BitConverter.ToInt32 (fnlBytes, 0);
+            PLog.DEBUG ("Got filename length=" + fileNameLengthBytes);
+
+            byte[] fnBytes = new byte[fileNameLengthBytes];
+            do {
+                got = SyncPseudoTcpSocket.Recv (conn,fnBytes, fileNameLengthBytes);
+                PLog.DEBUG ("Reading filename, got={0}", got);
+                UdpCallbacks.CondSleep (50, got, -1);
+            } while (got == -1);
+            SyncPseudoTcpSocket.Send(conn,ackBuffer,1);
+            PLog.DEBUG ("filename bytes=" + BitConverter.ToString(fnBytes));
+            string fileName = System.Text.Encoding.UTF8.GetString(fnBytes);
+            Console.WriteLine ("Receiving file: {0}", fileName);
+
+            byte[] fileSizeBytes = new byte[sizeof(long)];
+            do {
+                got = SyncPseudoTcpSocket.Recv(conn,fileSizeBytes, (uint)fileSizeBytes.Length);
+                PLog.DEBUG ("Reading file size, got={0}", got);
+                UdpCallbacks.CondSleep(50, got, -1);
+            } while (got == -1);
+            SyncPseudoTcpSocket.Send(conn, ackBuffer,1);
+            long size = (long)BitConverter.ToInt64 (fileSizeBytes, 0);
+            Console.WriteLine ("File size={0} bytes", size);
+
+            byte[] buffer = new byte[4 * 1024 * 1024];
+            int i = 0;
+
+            ConsoleProgress.Draw(i++, 0, size, ini, Console.WindowWidth / 2);
+
+            using (FileStream fileStream = new FileStream(fileName, FileMode.Create))
             {
-                string fileName = reader.ReadString();
-                long size = reader.ReadInt64();
+                long len = 0;
+                long read = 0;
 
-                byte[] buffer = new byte[4 * 1024 * 1024];
-
-                int i = 0;
-
-                ConsoleProgress.Draw(i++, 0, size, ini, Console.WindowWidth / 2);
-
-                using (FileStream fileStream = new FileStream(fileName, FileMode.Create))
+                while (read < size)
                 {
-                    long read = 0;
+                    do {
+                        PLog.DEBUG("Reading file data... so far total read={0}", read);
+                        len = SyncPseudoTcpSocket.Recv (conn, buffer, (uint)buffer.Length);
+                        UdpCallbacks.CondSleep(50, len, -1);
+                    } while (len == -1);
 
-                    while (read < size)
-                    {
-                        int toRecv = reader.ReadInt32();
+                    PLog.DEBUG ("Read {0} bytes of file data", len);
+                    fileStream.Write(buffer, 0, (int)len);
+                    read += len;
 
-                        ReadFragment(reader, toRecv, buffer);
+                    SyncPseudoTcpSocket.Send(conn, ackBuffer,1);
 
-                        fileStream.Write(buffer, 0, toRecv);
-
-                        read += toRecv;
-
-                        writer.Write(true);
-
-                        ConsoleProgress.Draw(i++, read, size, ini, Console.WindowWidth / 2);
-                    }
+                    ConsoleProgress.Draw(i++, read, size, ini, Console.WindowWidth / 2);
                 }
+
+                double MB = (double)size * 8.0 / (1024.0*1024.0);
+                double rxTime = (Environment.TickCount - ini) / 1000.0;
+                Console.WriteLine ();
+                Console.WriteLine("Receive time=" + rxTime + " secs");
+                Console.WriteLine("Av bandwidth=" + MB/rxTime + " Mbits/sec");
             }
-        }
-
-        static int ReadFragment(BinaryReader reader, int size, byte[] buffer)
-        {
-            int read = 0;
-
-            while (read < size)
-            {
-                read += reader.Read(buffer, read, size - read);
-            }
-
-            return read;
         }
     }
 }

--- a/Sender.cs
+++ b/Sender.cs
@@ -4,24 +4,41 @@ using System.IO;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using PseudoTcp;
+using System.Threading;
 
 namespace p2pcopy
 {
     static class Sender
     {
-        static internal void Run(Udt.Socket conn, string file, bool bVerbose)
+        static byte[] ackBuffer = new byte[1];
+
+        static internal void Run(PseudoTcpSocket conn, string file, bool bVerbose)
         {
             int ini = Environment.TickCount;
 
-            using (Udt.NetworkStream netStream = new Udt.NetworkStream(conn))
-            using (BinaryWriter writer = new BinaryWriter(netStream))
-            using (BinaryReader reader = new BinaryReader(netStream))
             using (FileStream fileReader = new FileStream(file, FileMode.Open, FileAccess.Read))
             {
                 long fileSize = new FileInfo(file).Length;
+                byte[] ackBuffer = new byte[1];
 
-                writer.Write(Path.GetFileName(file));
-                writer.Write(fileSize);
+                PLog.DEBUG ("Sending filename {0}", Path.GetFileName (file));
+                byte[] fileNameBytes = Encoding.UTF8.GetBytes (Path.GetFileName (file));
+                byte[] fileNameBytesLength = BitConverter.GetBytes (fileNameBytes.Length);
+                PLog.DEBUG ("Length of file name in bytes={0}", fileNameBytesLength);
+
+                SyncPseudoTcpSocket.Send(conn, fileNameBytesLength, (uint)fileNameBytesLength.Length);
+                SyncPseudoTcpSocket.Recv (conn, ackBuffer, 1);
+                PLog.DEBUG ("Sent filename length, ack={0}", ackBuffer [0]);
+
+                SyncPseudoTcpSocket.Send(conn, fileNameBytes, (uint)fileNameBytes.Length);
+                SyncPseudoTcpSocket.Recv (conn, ackBuffer, 1);
+                PLog.DEBUG ("Sent filename bytes {0}={1}, ack={2}",
+                    fileNameBytes, BitConverter.ToString(fileNameBytes), ackBuffer[0]);
+
+                SyncPseudoTcpSocket.Send(conn, BitConverter.GetBytes(fileSize), 8);
+                SyncPseudoTcpSocket.Recv (conn, ackBuffer, 1);
+                PLog.DEBUG ("Sent file size, ack={0}", ackBuffer [0]);
 
                 byte[] buffer = new byte[512 * 1024];
 
@@ -37,17 +54,25 @@ namespace p2pcopy
                         ? buffer.Length
                         : (int)(fileSize - pos);
 
+                    PLog.DEBUG ("File reading: pos={0}, fileSize={1}, toSend={2}", pos, fileSize, toSend);
+
                     fileReader.Read(buffer, 0, toSend);
 
                     int iteration = Environment.TickCount;
 
-                    writer.Write(toSend);
-                    conn.Send(buffer, 0, toSend);
+                    int sent;
+                    int totalSent = 0;
+                    int fragmentSize = toSend;
+                    while (totalSent < toSend) {
+                        sent = SendFragment (conn, buffer, fragmentSize);
 
-                    if (!reader.ReadBoolean())
-                    {
-                        Console.WriteLine("Error in transmission");
-                        return;
+                        totalSent += sent;
+                        if (sent < fragmentSize) {
+                            byte[] buffer2 = new byte[fragmentSize-sent];
+                            Buffer.BlockCopy(buffer, sent, buffer2, 0, buffer2.Length);
+                            fragmentSize = buffer2.Length;
+                            buffer = buffer2;
+                        }
                     }
 
                     pos += toSend;
@@ -61,13 +86,50 @@ namespace p2pcopy
                         Console.WriteLine("Current: {0} / s",
                             SizeConverter.ConvertToSizeString(toSend / (Environment.TickCount - iteration) * 1000));
 
-                        Console.WriteLine("BandwidthMbps {0} mbps.", conn.GetPerformanceInfo().Probe.BandwidthMbps);
-                        Console.WriteLine("RoundtripTime {0}.", conn.GetPerformanceInfo().Probe.RoundtripTime);
-                        Console.WriteLine("SendMbps {0}.", conn.GetPerformanceInfo().Local.SendMbps);
-                        Console.WriteLine("ReceiveMbps {0}.", conn.GetPerformanceInfo().Local.ReceiveMbps);
+                        //Console.WriteLine("BandwidthMbps {0} mbps.", conn.GetPerformanceInfo().Probe.BandwidthMbps);
+                        //Console.WriteLine("RoundtripTime {0}.", conn.GetPerformanceInfo().Probe.RoundtripTime);
+                        //Console.WriteLine("SendMbps {0}.", conn.GetPerformanceInfo().Local.SendMbps);
+                        //Console.WriteLine("ReceiveMbps {0}.", conn.GetPerformanceInfo().Local.ReceiveMbps);
                     }
                 }
             }
+
+            // TODO wait for confirmation all packets sent, either check PseudoTcpSocket queue,
+            // or a final ack from receiver
+            Thread.Sleep (15000); 
+
+            Console.WriteLine ();
+            Console.WriteLine ("Done!");
+        }
+
+        static int SendFragment(PseudoTcpSocket conn, byte[] buffer, int fragmentSize)
+        {
+            int got;
+            int sent;
+            do {
+                do {
+                    PLog.DEBUG ("Trying to send {0} bytes", fragmentSize);
+                    sent = SyncPseudoTcpSocket.Send (conn, buffer, (uint)fragmentSize);
+                    UdpCallbacks.AdjustClock(conn);
+                    UdpCallbacks.CondSleep (50, sent, -1);
+                } while (sent == -1);
+                PLog.DEBUG ("Tried sending fragment sized {0} with result {1}", fragmentSize, sent);
+
+                int start = Environment.TickCount;
+                do {
+                    PLog.DEBUG ("Waiting for ack for fragment");
+                    got = SyncPseudoTcpSocket.Recv (conn, ackBuffer, 1);
+                    UdpCallbacks.CondSleep (50, got, -1);
+                } while (got == -1 && Environment.TickCount < start + 5000);
+
+                if (1 == ackBuffer [0] && 1 == got) {
+                    PLog.DEBUG ("Received ack==1 ok");
+                } else {
+                    Console.WriteLine ("Error in transmission, will retry");
+                }
+            } while (-1 == got);
+
+            return sent;
         }
     }
 }

--- a/Sender.cs
+++ b/Sender.cs
@@ -104,30 +104,14 @@ namespace p2pcopy
 
         static int SendFragment(PseudoTcpSocket conn, byte[] buffer, int fragmentSize)
         {
-            int got;
             int sent;
             do {
-                do {
-                    PLog.DEBUG ("Trying to send {0} bytes", fragmentSize);
-                    sent = SyncPseudoTcpSocket.Send (conn, buffer, (uint)fragmentSize);
-                    UdpCallbacks.AdjustClock(conn);
-                    UdpCallbacks.CondSleep (50, sent, -1);
-                } while (sent == -1);
-                PLog.DEBUG ("Tried sending fragment sized {0} with result {1}", fragmentSize, sent);
-
-                int start = Environment.TickCount;
-                do {
-                    PLog.DEBUG ("Waiting for ack for fragment");
-                    got = SyncPseudoTcpSocket.Recv (conn, ackBuffer, 1);
-                    UdpCallbacks.CondSleep (50, got, -1);
-                } while (got == -1 && Environment.TickCount < start + 5000);
-
-                if (1 == ackBuffer [0] && 1 == got) {
-                    PLog.DEBUG ("Received ack==1 ok");
-                } else {
-                    Console.WriteLine ("Error in transmission, will retry");
-                }
-            } while (-1 == got);
+                PLog.DEBUG ("Trying to send {0} bytes", fragmentSize);
+                sent = SyncPseudoTcpSocket.Send (conn, buffer, (uint)fragmentSize);
+                UdpCallbacks.AdjustClock(conn);
+                UdpCallbacks.PollingSleep (sent, -1);
+            } while (sent == -1);
+            PLog.DEBUG ("Tried sending fragment sized {0} with result {1}", fragmentSize, sent);
 
             return sent;
         }

--- a/SyncPseudoTcpSocket.cs
+++ b/SyncPseudoTcpSocket.cs
@@ -5,35 +5,42 @@ using PseudoTcp;
 using gboolean = System.Boolean;
 using gint = System.Int32;
 using guint32 = System.UInt32;
+using guint64 = System.UInt64;
 using size_t = System.UInt32;
 
 namespace p2pcopy
 {
-	/** Helper class to synchronize relevant methods in PseudoTcpSocket */
-	public static class SyncPseudoTcpSocket
-	{
-		[MethodImpl(MethodImplOptions.Synchronized)]
-		public static gint Send(PseudoTcpSocket sock, byte[] buffer, guint32 len)
-		{
-			return sock.Send (buffer, len);
-		}
+    /** Helper class to synchronize relevant methods in PseudoTcpSocket */
+    public static class SyncPseudoTcpSocket
+    {
+        [MethodImpl(MethodImplOptions.Synchronized)]
+        public static gint Send(PseudoTcpSocket sock, byte[] buffer, guint32 len)
+        {
+            return sock.Send (buffer, len);
+        }
 
-		[MethodImpl(MethodImplOptions.Synchronized)]
-		public static gint Recv(PseudoTcpSocket sock, byte[] buffer, size_t len)
-		{
-			return sock.Recv (buffer, len);
-		}
+        [MethodImpl(MethodImplOptions.Synchronized)]
+        public static gint Recv(PseudoTcpSocket sock, byte[] buffer, size_t len)
+        {
+            return sock.Recv (buffer, len);
+        }
 
-		[MethodImpl(MethodImplOptions.Synchronized)]
-		public static gboolean NotifyPacket(PseudoTcpSocket sock, byte[] buffer, guint32 len)
-		{
-			return sock.NotifyPacket (buffer, len);
-		}
+        [MethodImpl(MethodImplOptions.Synchronized)]
+        public static gboolean NotifyPacket(PseudoTcpSocket sock, byte[] buffer, guint32 len)
+        {
+            return sock.NotifyPacket (buffer, len);
+        }
 
-		[MethodImpl(MethodImplOptions.Synchronized)]
-		public static void NotifyClock(PseudoTcpSocket sock)
-		{
-			sock.NotifyClock ();
-		}			
-	}
+        [MethodImpl(MethodImplOptions.Synchronized)]
+        public static void NotifyClock(PseudoTcpSocket sock)
+        {
+            sock.NotifyClock ();
+        }           
+
+        [MethodImpl(MethodImplOptions.Synchronized)]
+        public static gboolean GetNextClock(PseudoTcpSocket sock, ref guint64 timeout)
+        {
+            return sock.GetNextClock (ref timeout);
+        }
+    }
 }

--- a/SyncPseudoTcpSocket.cs
+++ b/SyncPseudoTcpSocket.cs
@@ -1,0 +1,39 @@
+﻿using System;
+using System.Runtime.CompilerServices;
+
+using PseudoTcp;
+using gboolean = System.Boolean;
+using gint = System.Int32;
+using guint32 = System.UInt32;
+using size_t = System.UInt32;
+
+namespace p2pcopy
+{
+	/** Helper class to synchronize relevant methods in PseudoTcpSocket */
+	public static class SyncPseudoTcpSocket
+	{
+		[MethodImpl(MethodImplOptions.Synchronized)]
+		public static gint Send(PseudoTcpSocket sock, byte[] buffer, guint32 len)
+		{
+			return sock.Send (buffer, len);
+		}
+
+		[MethodImpl(MethodImplOptions.Synchronized)]
+		public static gint Recv(PseudoTcpSocket sock, byte[] buffer, size_t len)
+		{
+			return sock.Recv (buffer, len);
+		}
+
+		[MethodImpl(MethodImplOptions.Synchronized)]
+		public static gboolean NotifyPacket(PseudoTcpSocket sock, byte[] buffer, guint32 len)
+		{
+			return sock.NotifyPacket (buffer, len);
+		}
+
+		[MethodImpl(MethodImplOptions.Synchronized)]
+		public static void NotifyClock(PseudoTcpSocket sock)
+		{
+			sock.NotifyClock ();
+		}			
+	}
+}

--- a/UdpCallbacks.cs
+++ b/UdpCallbacks.cs
@@ -1,0 +1,149 @@
+﻿using System;
+using PseudoTcp;
+using System.IO;
+using System.Diagnostics;
+
+using System.Net.Sockets;
+using System.Net;
+using System.Text;
+using System.Threading;
+
+namespace p2pcopy
+{
+    public class UdpCallbacks
+    {
+        PseudoTcpSocket pseudoSock;
+        string localAddr;
+        int localPort;
+        string remoteAddr;
+        int remotePort;
+        UdpClient udpcTx;
+        UdpClient udpcRx;
+        IPEndPoint rxEndpoint;
+
+        public void Init (
+            string localAddr, int localPort, string remoteAddr, int remotePort,
+            PseudoTcpSocket pseudoSock)
+        {
+            this.localAddr = localAddr;
+            this.localPort = localPort;
+            this.remoteAddr = remoteAddr;
+            this.remotePort = remotePort;
+            this.pseudoSock = pseudoSock;
+
+            udpcTx = new UdpClient (remoteAddr, remotePort);
+            rxEndpoint = new IPEndPoint(IPAddress.Any, localPort);
+            udpcRx = new UdpClient(rxEndpoint);
+
+            BeginReceive();
+        }
+            
+        public void BeginReceive()
+        {
+            udpcRx.BeginReceive(new AsyncCallback(MessageReceived), null);
+            PLog.DEBUG("Listening on UDP port {0}", localPort);
+        }
+
+        public void MessageReceived(IAsyncResult ar)
+        {
+            byte[] receiveBytes = udpcRx.EndReceive(ar, ref rxEndpoint);
+            PLog.DEBUG($"Received {0} bytes", receiveBytes.Length);
+                
+            SyncPseudoTcpSocket.NotifyPacket(pseudoSock, receiveBytes, (uint)receiveBytes.Length);
+            SyncPseudoTcpSocket.NotifyClock(pseudoSock);
+
+            BeginReceive(); // Listen again
+        }
+            
+        public PseudoTcpSocket.WriteResult WritePacket(
+            PseudoTcp.PseudoTcpSocket sock,
+            byte[] buffer,
+            uint len,
+            object user_data)
+        {
+            try
+            {
+                this.udpcTx.Send(buffer, (int)len);
+                PLog.DEBUG("Sent {0} bytes to UDPClient at {1}:{2}", len, remoteAddr, remotePort);
+                return PseudoTcpSocket.WriteResult.WR_SUCCESS;
+            }
+            catch (Exception e)
+            {
+                Console.WriteLine (e.ToString ());
+                return PseudoTcpSocket.WriteResult.WR_FAIL;
+            }
+        }
+
+        public void Opened(PseudoTcp.PseudoTcpSocket sock, object data)
+        {
+            PLog.DEBUG ("UdpCallbacks.Opened");
+        }
+
+        public void Closed(PseudoTcpSocket sock, uint err, object data)
+        {
+            PLog.DEBUG ("UdpCallbacks.Closed: err={0}", err);
+        }
+
+        public void Writable (PseudoTcp.PseudoTcpSocket sock, object data)
+        {
+            PLog.DEBUG ("UdpCallbacks.Writeable");
+        }
+
+        public static void AdjustClock(PseudoTcp.PseudoTcpSocket sock)
+        {
+            ulong timeout = 0;
+
+            if (sock.GetNextClock(ref timeout))
+            {
+                uint now = PseudoTcpSocket.GetMonotonicTime();
+
+                if (now < timeout)
+                    timeout -= now;
+                else
+                    timeout = now - timeout;
+
+                if (timeout > 900)
+                    timeout = 100;
+
+                /// Console.WriteLine ("Socket {0}: Adjusting clock to {1} ms", sock, timeout);
+
+                Timer timer = null;
+                timer = new System.Threading.Timer(
+                    (obj) =>
+                    {
+                        NotifyClock(sock);
+
+                        // Very occasionally null (why?)
+                        if (null!= timer) {
+                            timer.Dispose();
+                        }
+                    },
+                    null,
+                    (long)timeout,
+                    Timeout.Infinite);
+            }
+            else
+            {
+                /*left_closed = true;
+
+                        if (left_closed && right_closed)
+                            g_main_loop_quit (mainloop);*/
+            }
+        }
+
+        static void NotifyClock(PseudoTcp.PseudoTcpSocket sock)
+        {
+            //g_debug ("Socket %p: Notifying clock", sock);
+            SyncPseudoTcpSocket.NotifyClock(sock);
+            AdjustClock(sock);
+        }
+
+        public static void CondSleep(int sleep, long value, long sleepIf)
+        {
+            if (value == sleepIf)
+            {
+                Thread.Sleep (sleep);
+            }
+        }
+    }
+}

--- a/p2pcopy.csproj
+++ b/p2pcopy.csproj
@@ -57,6 +57,7 @@
     <Compile Include="PLog.cs" />
     <Compile Include="SyncPseudoTcpSocket.cs" />
     <Compile Include="UdpCallbacks.cs" />
+    <Compile Include="Config.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="App.config">

--- a/p2pcopy.csproj
+++ b/p2pcopy.csproj
@@ -51,7 +51,7 @@
     <Compile Include="Sender.cs" />
     <Compile Include="SizeConverter.cs" />
     <Compile Include="StunClient.cs" />
-    <Compile Include="..\PseudoTcpSharp\pseudotcp.cs">
+    <Compile Include=".\PseudoTcpSharp\pseudotcp.cs">
       <Link>pseudotcp.cs</Link>
     </Compile>
     <Compile Include="PLog.cs" />

--- a/p2pcopy.csproj
+++ b/p2pcopy.csproj
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -38,6 +38,9 @@
     <Reference Include="UdtProtocol">
       <HintPath>udt64\UdtProtocol.dll</HintPath>
     </Reference>
+    <Reference Include="Costura">
+      <HintPath>packages\Costura.Fody.4.0.0\lib\net40\Costura.dll</HintPath>
+    </Reference>
   </ItemGroup>
   <ItemGroup>
     <Compile Include="ConsoleProgress.cs" />
@@ -48,6 +51,12 @@
     <Compile Include="Sender.cs" />
     <Compile Include="SizeConverter.cs" />
     <Compile Include="StunClient.cs" />
+    <Compile Include="..\PseudoTcpSharp\pseudotcp.cs">
+      <Link>pseudotcp.cs</Link>
+    </Compile>
+    <Compile Include="PLog.cs" />
+    <Compile Include="SyncPseudoTcpSocket.cs" />
+    <Compile Include="UdpCallbacks.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="App.config">
@@ -64,13 +73,10 @@
   </ItemGroup>
   <ItemGroup />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <Import Project="packages\Fody.1.28.3\build\Fody.targets" Condition="Exists('packages\Fody.1.28.3\build\Fody.targets')" />
-  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
-    <PropertyGroup>
-      <ErrorText>This project references NuGet package(s) that are missing on this computer. Enable NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
-    </PropertyGroup>
-    <Error Condition="!Exists('packages\Fody.1.28.3\build\Fody.targets')" Text="$([System.String]::Format('$(ErrorText)', 'packages\Fody.1.28.3\build\Fody.targets'))" />
-  </Target>
+  <Import Project="packages\Fody.5.0.0.0\build\Fody.targets" Condition="Exists('packages\Fody.5.0.0.0\build\Fody.targets')" />
+  <Import Project="packages\Costura.Fody.4.0.0.0\build\Costura.Fody.props" Condition="Exists('packages\Costura.Fody.4.0.0.0\build\Costura.Fody.props')" />
+  <Import Project="packages\Fody.5.0.0.0\build\Fody.targets" Condition="Exists('packages\Fody.5.0.0.0\build\Fody.targets')" />
+  <Import Project="packages\Costura.Fody.4.0.0.0\build\Costura.Fody.props" Condition="Exists('packages\Costura.Fody.4.0.0.0\build\Costura.Fody.props')" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/packages.config
+++ b/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Costura.Fody" version="1.3.3.0" targetFramework="net45" />
-  <package id="Fody" version="1.28.3" targetFramework="net45" developmentDependency="true" />
+  <package id="Costura.Fody" version="4.0.0" targetFramework="net45" />
+  <package id="Fody" version="5.0.0" targetFramework="net45" developmentDependency="true" />
 </packages>

--- a/packages/repositories.config
+++ b/packages/repositories.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <repositories>
-  <repository path="..\packages.config" />
+  <repository path="../packages.config" />
 </repositories>


### PR DESCRIPTION
Fixes https://github.com/psantosl/p2pcopy/issues/4 and https://github.com/psantosl/p2pcopy/issues/2 : Integrate PseudoTcpSharp + UdpClient into p2pcopy.

### Notes
* No longer needs any changes to PseudoTcpSocket code, but perf is improved by setting `MAX_RTO=1000`
* Bandwidth between AWS -> natted router ~= 1Mbit/s
* Bandwidth between two AWS instances ~=3Mbit/s
* Synchronized wrappers in `SyncPseudoTcpSocket` needed due to concurrent calls to PseudoTcpSocket from timer calls to `NotifyPacket` and the incoming UDP message handler. Without synchronization, packet queue corruption observed during large sends.
* Switched to a non-https time service due to certificate problems in my version of mono.
