### PR TITLE
Convert to .NET 5 & copy IP to clipboard

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,12 +4,52 @@ on: push
 env:
   NUGET_URL: https://dist.nuget.org/win-x86-commandline/v5.4.0/nuget.exe
 jobs:
-  build_and_deploy:
-    runs-on: ubuntu-18.04
+  build:
+    runs-on: ${{ matrix.os }}
+
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest, macOS-latest]
+      fail-fast: false
+
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v2
+
+    - name: Setup .NET 5
+      uses: actions/setup-dotnet@v1.7.2
+      with:
+        dotnet-version: 5.0.x
+
     - name: Build
-      run: |
-        mkdir .nuget && cd .nuget && wget $NUGET_URL && cd ..
-        mono .nuget/nuget.exe restore p2pcopy.sln
-        msbuild
+      run: dotnet build -c Release
+
+  publish:
+    needs: build
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        runtime-framework: [win-x64, linux-x64, osx-x64, win-x86, win-arm, win-arm64, linux-musl-x64, linux-arm, linux-arm64]
+      fail-fast: false
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Inject slug/short variables
+      uses: rlespinasse/github-slug-action@v3.x
+
+    - name: Setup .NET 5
+      uses: actions/setup-dotnet@v1.7.2
+      with:
+        dotnet-version: 5.0.x
+
+    - name: Publish ${{ matrix.runtime-framework }}
+      run: dotnet publish -c Release -r ${{ matrix.runtime-framework }} /p:PublishProfile=SingleFileSelfContainer -o artifacts/${{ matrix.runtime-framework }}
+
+    - name: Upload Artifact
+      uses: actions/upload-artifact@v2
+      with:
+        name: p2pcopy-${{ matrix.runtime-framework }}-ci-${{ github.run_number }}
+        path: |
+          artifacts/${{ matrix.runtime-framework }}
+        if-no-files-found: error

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
 
     strategy:
       matrix:
-        runtime-framework: [win-x64, linux-x64, osx-x64, win-x86, win-arm, win-arm64, linux-musl-x64, linux-arm, linux-arm64]
+        runtime-identifier: [win-x64, linux-x64, osx-x64, win-x86, win-arm, win-arm64, linux-musl-x64, linux-arm, linux-arm64]
       fail-fast: false
 
     steps:
@@ -43,13 +43,13 @@ jobs:
       with:
         dotnet-version: 5.0.x
 
-    - name: Publish ${{ matrix.runtime-framework }}
-      run: dotnet publish -c Release -r ${{ matrix.runtime-framework }} /p:PublishProfile=SingleFileSelfContainer -o artifacts/${{ matrix.runtime-framework }}
+    - name: Publish ${{ matrix.runtime-identifier }}
+      run: dotnet publish -c Release -r ${{ matrix.runtime-identifier }} /p:PublishProfile=SingleFileSelfContainer -o artifacts/${{ matrix.runtime-identifier }}
 
     - name: Upload Artifact
       uses: actions/upload-artifact@v2
       with:
-        name: p2pcopy-${{ matrix.runtime-framework }}-ci-${{ github.run_number }}
+        name: p2pcopy-${{ matrix.runtime-identifier }}-ci-${{ github.run_number }}
         path: |
-          artifacts/${{ matrix.runtime-framework }}
+          artifacts/${{ matrix.runtime-identifier }}
         if-no-files-found: error

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
 bin
 obj
 .vs
+.vscode
 packages/
 .nuget/
+artifacts/

--- a/App.config
+++ b/App.config
@@ -1,6 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8" ?>
-<configuration>
-    <startup> 
-        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5" />
-    </startup>
-</configuration>

--- a/Program.cs
+++ b/Program.cs
@@ -1,5 +1,5 @@
 using System.IO;
-﻿using System;
+using System;
 using System.Net.Sockets;
 using System.Collections.Generic;
 using System.Net;
@@ -60,6 +60,7 @@ namespace p2pcopy
                     return;
 
                 Console.WriteLine("Tell this to your peer: {0}", p2pEndPoint.External.ToString());
+                TextCopy.ClipboardService.SetText(p2pEndPoint.External.ToString());
 
                 Console.WriteLine();
                 Console.WriteLine();

--- a/Properties/PublishProfiles/SingleFileSelfContainer.pubxml
+++ b/Properties/PublishProfiles/SingleFileSelfContainer.pubxml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+This file is used by the publish/package process of your Web project.
+You can customize the behavior of this process by editing this 
+MSBuild file.
+-->
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+
+  <PropertyGroup>
+    <DebugType>None</DebugType>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <PublishSingleFile>true</PublishSingleFile>
+    <SelfContained>true</SelfContained>
+    <PublishTrimmed>true</PublishTrimmed>
+    <TrimMode>link</TrimMode>
+    <IncludeNativeLibrariesForSelfExtract>true</IncludeNativeLibrariesForSelfExtract>
+  </PropertyGroup>
+
+</Project>

--- a/p2pcopy.csproj
+++ b/p2pcopy.csproj
@@ -6,10 +6,17 @@
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
   </PropertyGroup>
 
-
   <ItemGroup>
     <PackageReference Include="UdtSharp" Version="0.1.0--date20201004-0708.git-86da089" />
     <PackageReference Include="TextCopy" Version="4.3.1" />
   </ItemGroup>
+
+  <Target Name="RenameApp" AfterTargets="Publish">
+    <ItemGroup>
+      <FilesToRename Include="$(PublishDir)\$(AssemblyName)*" />
+    </ItemGroup>
+    <Message Text="## Renaming @(FilesToRename) to @(FilesToRename -> Replace('$(RuntimeIdentifier)\$(AssemblyName)', '$(RuntimeIdentifier)\$(AssemblyName)-$(RuntimeIdentifier)'))" Importance="High" />
+    <Move SourceFiles="@(FilesToRename)" DestinationFiles="@(FilesToRename -> Replace('$(RuntimeIdentifier)\$(AssemblyName)', '$(RuntimeIdentifier)\$(AssemblyName)-$(RuntimeIdentifier)'))" />
+  </Target>
 
 </Project>

--- a/p2pcopy.csproj
+++ b/p2pcopy.csproj
@@ -1,67 +1,15 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
   <PropertyGroup>
-    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
-    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-    <ProjectGuid>{6DAB1891-9A31-471A-BAC4-370C6D1D3801}</ProjectGuid>
+    <TargetFramework>net5.0</TargetFramework>
     <OutputType>Exe</OutputType>
-    <AppDesignerFolder>Properties</AppDesignerFolder>
-    <RootNamespace>p2pcopy</RootNamespace>
-    <AssemblyName>p2pcopy</AssemblyName>
-    <TargetFrameworkVersion>v4.7.1</TargetFrameworkVersion>
-    <FileAlignment>512</FileAlignment>
-    <NuGetPackageImportStamp>093ed4b2</NuGetPackageImportStamp>
+    <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
   </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
-    <PlatformTarget>x64</PlatformTarget>
-    <DebugSymbols>true</DebugSymbols>
-    <DebugType>full</DebugType>
-    <Optimize>false</Optimize>
-    <OutputPath>bin\Debug\</OutputPath>
-    <DefineConstants>DEBUG;TRACE</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
-    <Prefer32Bit>false</Prefer32Bit>
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-    <PlatformTarget>AnyCPU</PlatformTarget>
-    <DebugType>pdbonly</DebugType>
-    <Optimize>true</Optimize>
-    <OutputPath>bin\Release\</OutputPath>
-    <DefineConstants>TRACE</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
-  </PropertyGroup>
+
+
   <ItemGroup>
-    <Reference Include="System" />
-    <Reference Include="udtsharp">
-      <HintPath>packages\UdtSharp.0.1.0--date20201004-0708.git-86da089\lib\netstandard2.0\udtsharp.dll</HintPath>
-    </Reference>
+    <PackageReference Include="UdtSharp" Version="0.1.0--date20201004-0708.git-86da089" />
+    <PackageReference Include="TextCopy" Version="4.3.1" />
   </ItemGroup>
-  <ItemGroup>
-    <Compile Include="ConsoleProgress.cs" />
-    <Compile Include="InternetTime.cs" />
-    <Compile Include="Program.cs" />
-    <Compile Include="Properties\AssemblyInfo.cs" />
-    <Compile Include="Receiver.cs" />
-    <Compile Include="Sender.cs" />
-    <Compile Include="SizeConverter.cs" />
-    <Compile Include="StunClient.cs" />
-  </ItemGroup>
-  <ItemGroup>
-    <None Include="App.config">
-      <SubType>Designer</SubType>
-    </None>
-    <None Include="packages.config" />
-  </ItemGroup>
-  <ItemGroup />
-  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
-       Other similar extension points exist, see Microsoft.Common.targets.
-  <Target Name="BeforeBuild">
-  </Target>
-  <Target Name="AfterBuild">
-  </Target>
-  -->
+
 </Project>

--- a/packages.config
+++ b/packages.config
@@ -1,4 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<packages>
-  <package id="UdtSharp" version="0.1.0--date20201004-0708.git-86da089" targetFramework="net471" />
-</packages>

--- a/packages/repositories.config
+++ b/packages/repositories.config
@@ -1,4 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<repositories>
-  <repository path="..\packages.config" />
-</repositories>


### PR DESCRIPTION
* Convert to .NET 5 (no code changes required).
* In the CI pipeline, publish automatically self-contained executables for a number of target-runtimes [Tested win-x64, win-x84 and linux-x64 executables]
* Copy own IP to the clipboard (using [TextCopy](https://github.com/CopyText/TextCopy), see [this](https://github.com/CopyText/TextCopy)) [Tested only in Windows]
* Minor linter fixes in the README.

Happy to split the PR if needed, but most changes depend on the .NET 5 conversion.

A possible follow up of this PR, related to the CI pipeline, could be adding a manual trigger to publish a GitHub release whenever you want and automatically attach the published artifacts there.